### PR TITLE
Adding GPG key for RedHat family OSes.

### DIFF
--- a/nginx/package/official.sls
+++ b/nginx/package/official.sls
@@ -3,6 +3,18 @@
 include:
   - nginx.package
 
+{% if grains['os_family'] == 'RedHat' %}
+/etc/pki/rpm-gpg/RPM-GPG-KEY-nginx:
+  file.managed:
+    - source: http://nginx.org/keys/nginx_signing.key
+    - source_hash: md5=016d27313adbf180e545ae9fadd11826
+    - user: root
+    - group: root
+    - mode: 644
+    - require_in:
+      - pkgrepo: nginx_repo
+{% endif %}
+
 nginx_repo:
   pkgrepo.managed:
     {% if grains['os_family'] == 'Debian' %}
@@ -10,6 +22,7 @@ nginx_repo:
     - key_url: {{ nginx_repo.key_url }}
     {% elif grains['os_family'] == 'RedHat' %}
     - name: {{ nginx_repo.name }}
+    - gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-nginx
     - humanname: {{ nginx_repo.humanname }}
         {% if 'mirrorlist' in nginx_repo %}
     - mirrorlist: {{ nginx_repo.mirrorlist }}


### PR DESCRIPTION
By default CentOs 6 uses gpgcheck. Adding GPG signing key to system storage to make official package installation pass the check.
